### PR TITLE
Potential fix for code scanning alert no. 5: Uncontrolled command line

### DIFF
--- a/insta_monitering/subpinsta.py
+++ b/insta_monitering/subpinsta.py
@@ -18,8 +18,8 @@ def instasubprocess(user, tags, type, productId):
             + " "
             + productId
         )
-        command = child_env + " " + file_pocessing
-        result = subprocess.Popen(command, shell=True)
+        command = [child_env, os.path.join(os.getcwd(), "insta_datafetcher.py"), user, tags, type, productId]
+        result = subprocess.Popen(command)
         result.wait()
     except:
         print("error::instasubprocess>>", sys.exc_info()[1])


### PR DESCRIPTION
Potential fix for [https://github.com/ymugoder/Python/security/code-scanning/5](https://github.com/ymugoder/Python/security/code-scanning/5)

To fix the problem, we should avoid constructing the command string by concatenating user inputs directly. Instead, we can pass the user inputs as arguments to the Python script using a list, which `subprocess.Popen` can safely handle without invoking the shell. This approach ensures that the inputs are treated as arguments rather than executable code.

1. Modify the `instasubprocess` function to construct the command as a list of arguments.
2. Update the `subprocess.Popen` call to use this list without `shell=True`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
